### PR TITLE
Add ability to enable touch events on target view

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Line animation duration
 ### performClick(boolean)
 Perform a click on target view
 
-### allowTargetViewTouch(boolean)
+### enableTargetViewTouch(boolean)
 Whether the target view is allowed to receive touch events.
 
 ### usageId(String)
@@ -134,8 +134,8 @@ Unique id for each spotlight
 ### dismissOnTouch(boolean)
 Dismiss spotlight on touch outside
 
-### enableDismissAfterShown(boolean)
-Dismiss spotlight on touch outside after spotlight is completely visible
+### enableDismissDuringEntryAnimation(boolean)
+Whether dismiss on touch or back press is allowed before the entry animation has completed.
 
 # Configuration Method
 ```java

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Line animation duration
 ### performClick(boolean)
 Perform a click on target view
 
+### allowTargetViewTouch(boolean)
+Whether the target view is allowed to receive touch events.
+
 ### usageId(String)
 Unique id for each spotlight
 

--- a/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightConfig.java
+++ b/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightConfig.java
@@ -17,8 +17,9 @@ public class SpotlightConfig {
     private int padding;
     private boolean dismissOnTouch;
     private boolean dismissOnBackpress;
+    private boolean enableDismissDuringEntryAnimation;
     private boolean performClick;
-    private boolean allowTargetViewTouch;
+    private boolean enableTargetViewTouch;
     private int headingTvSize;
     private int headingTvColor;
     private CharSequence headingTvText;
@@ -39,7 +40,8 @@ public class SpotlightConfig {
         this.dismissOnTouch = true;
         this.dismissOnBackpress=true;
         this.performClick = true;
-        this.allowTargetViewTouch = true;
+        this.enableTargetViewTouch = false;
+        this.enableDismissDuringEntryAnimation = false;
         this.headingTvSize = 24;
         this.headingTvColor = Color.parseColor("#eb273f");
         this.headingTvText = "Hello";
@@ -107,12 +109,12 @@ public class SpotlightConfig {
         this.performClick = performClick;
     }
 
-    public boolean allowTargetViewTouch() {
-        return allowTargetViewTouch;
+    public boolean enableTargetViewTouch() {
+        return enableTargetViewTouch;
     }
 
-    public void setAllowTargetViewTouch(boolean allowTargetViewTouch) {
-        this.allowTargetViewTouch = allowTargetViewTouch;
+    public void setEnableTargetViewTouch(boolean allowTargetViewTouch) {
+        this.enableTargetViewTouch = allowTargetViewTouch;
     }
 
     public int getHeadingTvSize() {
@@ -201,5 +203,13 @@ public class SpotlightConfig {
 
     public void setDismissOnBackpress(boolean dismissOnBackpress) {
         this.dismissOnBackpress = dismissOnBackpress;
+    }
+
+    public boolean enableDismissDuringEntryAnimation() {
+        return enableDismissDuringEntryAnimation;
+    }
+
+    public void setEnableDismissDuringEntryAnimation(boolean enableDismissDuringEntryAnimation) {
+        this.enableDismissDuringEntryAnimation = enableDismissDuringEntryAnimation;
     }
 }

--- a/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightConfig.java
+++ b/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightConfig.java
@@ -17,7 +17,8 @@ public class SpotlightConfig {
     private int padding;
     private boolean dismissOnTouch;
     private boolean dismissOnBackpress;
-    private boolean isPerformClick;
+    private boolean performClick;
+    private boolean allowTargetViewTouch;
     private int headingTvSize;
     private int headingTvColor;
     private CharSequence headingTvText;
@@ -37,7 +38,8 @@ public class SpotlightConfig {
         this.padding = 20;
         this.dismissOnTouch = true;
         this.dismissOnBackpress=true;
-        this.isPerformClick = true;
+        this.performClick = true;
+        this.allowTargetViewTouch = true;
         this.headingTvSize = 24;
         this.headingTvColor = Color.parseColor("#eb273f");
         this.headingTvText = "Hello";
@@ -97,12 +99,20 @@ public class SpotlightConfig {
         this.dismissOnTouch = dismissOnTouch;
     }
 
-    public boolean isPerformClick() {
-        return isPerformClick;
+    public boolean performClick() {
+        return performClick;
     }
 
     public void setPerformClick(boolean performClick) {
-        isPerformClick = performClick;
+        this.performClick = performClick;
+    }
+
+    public boolean allowTargetViewTouch() {
+        return allowTargetViewTouch;
+    }
+
+    public void setAllowTargetViewTouch(boolean allowTargetViewTouch) {
+        this.allowTargetViewTouch = allowTargetViewTouch;
     }
 
     public int getHeadingTvSize() {

--- a/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightView.java
+++ b/Spotlight-library/src/main/java/com/wooplr/spotlight/SpotlightView.java
@@ -299,7 +299,7 @@ public class SpotlightView extends FrameLayout {
     /**
      * Show the view based on the configuration
      * Reveal is available only for Lollipop and above in other only fadein will work
-     * To support reveal in older versions use github.com/ozodrukh/CircularRevealf
+     * To support reveal in older versions use github.com/ozodrukh/CircularReveal
      *
      * @param activity
      */
@@ -316,8 +316,12 @@ public class SpotlightView extends FrameLayout {
         handler.postDelayed(new Runnable() {
                                 @Override
                                 public void run() {
-                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                                    if (getWindowToken() == null) {
+                                        Log.w(TAG, "Cannot show, view is not attached to a window.");
+                                        return;
+                                    }
 
+                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                                         if (isRevealAnimationEnabled)
                                             startRevealAnimation(activity);
                                         else {

--- a/app/src/main/java/com/example/spotlight/MainActivity.java
+++ b/app/src/main/java/com/example/spotlight/MainActivity.java
@@ -130,7 +130,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 .lineAndArcColor(Color.parseColor("#eb273f"))
                 .dismissOnTouch(true)
                 .dismissOnBackPress(true)
-                .enableDismissAfterShown(true)
+                .enableDismissDuringEntryAnimation(false)
                 .usageId(usageId) //UNIQUE ID
                 .show();
     }


### PR DESCRIPTION
- Add ability to enable touch events on target view (issue #19)
- Fix enabling/disabling dismissal during the entry animation (issue #18)
- Protect against showing/hiding SpotlightView when it's not attached to a window
- Consume touch events so user can't interact with views underneath the SpotlightView